### PR TITLE
feat(bootstrap): adds bootstrap 4 and loads by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/GasStationTV/react-coding-exercise#readme",
   "dependencies": {
+    "bootstrap": "^4.0.0-alpha.2",
     "react": "0.14.7",
     "react-dom": "^0.14.7"
   },

--- a/routes.js
+++ b/routes.js
@@ -1,8 +1,8 @@
 import React         from 'react';
 import { Route }     from 'react-router';
-
 import HomeView  from './views/RootView';
 import FishView  from './views/FishView';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 const routes = (
   <Route path="/" component={HomeView} >


### PR DESCRIPTION
It seems to be a bit of a hassle for people to load in bootstrap (v3 uses less files and it is a bit more work to load in v3 css dist files with some of the font issues).
This should streamline the process of people trying to load in bootstrap. If they need to do more, they'll have to figure it out.
